### PR TITLE
CNTRLPLANE-634: Limit external-dns AWS API usage

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -208,18 +208,25 @@ const (
 	AWSExternalDNSProvider   ExternalDNSProvider = "aws"
 	AzureExternalDNSProvider ExternalDNSProvider = "azure"
 	GCPExternalDNSProvider   ExternalDNSProvider = "google"
+
+	// DefaultExternalDNSInterval is the default reconciliation interval for external-dns.
+	DefaultExternalDNSInterval = 1 * time.Minute
+	// DefaultExternalDNSAWSZonesCacheDuration is the default cache duration for AWS Route53 hosted zones.
+	DefaultExternalDNSAWSZonesCacheDuration = 1 * time.Hour
 )
 
 type ExternalDNSDeployment struct {
-	Namespace         *corev1.Namespace
-	Image             string
-	ServiceAccount    *corev1.ServiceAccount
-	Provider          ExternalDNSProvider
-	DomainFilter      string
-	CredentialsSecret *corev1.Secret
-	TxtOwnerId        string
-	Proxy             *configv1.Proxy
-	GoogleProject     string
+	Namespace             *corev1.Namespace
+	Image                 string
+	ServiceAccount        *corev1.ServiceAccount
+	Provider              ExternalDNSProvider
+	DomainFilter          string
+	CredentialsSecret     *corev1.Secret
+	TxtOwnerId            string
+	Proxy                 *configv1.Proxy
+	GoogleProject         string
+	Interval              time.Duration
+	AWSZonesCacheDuration time.Duration
 }
 
 func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
@@ -227,6 +234,14 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 	txtOwnerId := o.TxtOwnerId
 	if txtOwnerId == "" {
 		txtOwnerId = uuid.NewString()
+	}
+	interval := o.Interval
+	if interval == 0 {
+		interval = DefaultExternalDNSInterval
+	}
+	awsZonesCacheDuration := o.AWSZonesCacheDuration
+	if awsZonesCacheDuration == 0 {
+		awsZonesCacheDuration = DefaultExternalDNSAWSZonesCacheDuration
 	}
 	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -270,7 +285,7 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 								"--txt-suffix=-external-dns",
 								fmt.Sprintf("--txt-owner-id=%s", txtOwnerId),
 								fmt.Sprintf("--label-filter=%s!=%s", hyperv1.RouteVisibilityLabel, hyperv1.RouteVisibilityPrivate),
-								"--interval=1m",
+								fmt.Sprintf("--interval=%s", interval),
 								"--txt-cache-interval=1h",
 							},
 							Ports: []corev1.ContainerPort{{Name: "metrics", ContainerPort: 7979}},
@@ -351,7 +366,7 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args,
 			"--aws-zone-type=public",
 			"--aws-batch-change-interval=10s",
-			"--aws-zones-cache-duration=1h",
+			fmt.Sprintf("--aws-zones-cache-duration=%s", awsZonesCacheDuration),
 		)
 	case AzureExternalDNSProvider:
 		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args,

--- a/cmd/install/assets/hypershift_operator_test.go
+++ b/cmd/install/assets/hypershift_operator_test.go
@@ -3,6 +3,7 @@ package assets
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 
@@ -481,6 +482,110 @@ func TestHyperShiftOperatorDeployment_Build(t *testing.T) {
 			g.Expect(deployment.Spec.Template.Spec.Volumes).To(BeEquivalentTo(test.expectedVolumes))
 			g.Expect(deployment.Spec.Template.Spec.Containers[0].VolumeMounts).To(BeEquivalentTo(test.expectedVolumeMounts))
 			g.Expect(deployment.Spec.Template.Spec.Containers[0].Env).To(ContainElements(test.expectedEnvVars))
+		})
+	}
+}
+
+func TestExternalDNSDeployment_Build(t *testing.T) {
+	baseDeployment := func() ExternalDNSDeployment {
+		return ExternalDNSDeployment{
+			Namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: "hypershift"},
+			},
+			Image: "external-dns:latest",
+			ServiceAccount: &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{Name: "external-dns"},
+			},
+			Provider:     AWSExternalDNSProvider,
+			DomainFilter: "example.com",
+			CredentialsSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "dns-creds"},
+			},
+			TxtOwnerId: "test-owner",
+		}
+	}
+
+	tests := map[string]struct {
+		modify     func(*ExternalDNSDeployment)
+		expectArgs func(g Gomega, args []string)
+	}{
+		"When no interval is specified, it should default to 1m": {
+			modify: func(d *ExternalDNSDeployment) {},
+			expectArgs: func(g Gomega, args []string) {
+				g.Expect(args).To(ContainElement("--interval=1m0s"))
+			},
+		},
+		"When interval is set to 5m, it should use 5m in the args": {
+			modify: func(d *ExternalDNSDeployment) {
+				d.Interval = 5 * time.Minute
+			},
+			expectArgs: func(g Gomega, args []string) {
+				g.Expect(args).To(ContainElement("--interval=5m0s"))
+			},
+		},
+		"When interval is set to 10m, it should use 10m in the args": {
+			modify: func(d *ExternalDNSDeployment) {
+				d.Interval = 10 * time.Minute
+			},
+			expectArgs: func(g Gomega, args []string) {
+				g.Expect(args).To(ContainElement("--interval=10m0s"))
+			},
+		},
+		"When no AWS zones cache duration is specified, it should default to 1h for AWS provider": {
+			modify: func(d *ExternalDNSDeployment) {},
+			expectArgs: func(g Gomega, args []string) {
+				g.Expect(args).To(ContainElement("--aws-zones-cache-duration=1h0m0s"))
+			},
+		},
+		"When AWS zones cache duration is set to 30m, it should use 30m in the args": {
+			modify: func(d *ExternalDNSDeployment) {
+				d.AWSZonesCacheDuration = 30 * time.Minute
+			},
+			expectArgs: func(g Gomega, args []string) {
+				g.Expect(args).To(ContainElement("--aws-zones-cache-duration=30m0s"))
+			},
+		},
+		"When both interval and AWS zones cache duration are customized, it should use both custom values": {
+			modify: func(d *ExternalDNSDeployment) {
+				d.Interval = 5 * time.Minute
+				d.AWSZonesCacheDuration = 2 * time.Hour
+			},
+			expectArgs: func(g Gomega, args []string) {
+				g.Expect(args).To(ContainElement("--interval=5m0s"))
+				g.Expect(args).To(ContainElement("--aws-zones-cache-duration=2h0m0s"))
+			},
+		},
+		"When provider is Azure, it should not include AWS zones cache duration": {
+			modify: func(d *ExternalDNSDeployment) {
+				d.Provider = AzureExternalDNSProvider
+			},
+			expectArgs: func(g Gomega, args []string) {
+				g.Expect(args).To(ContainElement("--interval=1m0s"))
+				for _, arg := range args {
+					g.Expect(arg).NotTo(ContainSubstring("--aws-zones-cache-duration"))
+				}
+			},
+		},
+		"When provider is GCP, it should not include AWS zones cache duration": {
+			modify: func(d *ExternalDNSDeployment) {
+				d.Provider = GCPExternalDNSProvider
+			},
+			expectArgs: func(g Gomega, args []string) {
+				g.Expect(args).To(ContainElement("--interval=1m0s"))
+				for _, arg := range args {
+					g.Expect(arg).NotTo(ContainSubstring("--aws-zones-cache-duration"))
+				}
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			d := baseDeployment()
+			test.modify(&d)
+			deployment := d.Build()
+			test.expectArgs(g, deployment.Spec.Template.Spec.Containers[0].Args)
 		})
 	}
 }

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -113,6 +113,8 @@ type Options struct {
 	ExternalDNSTxtOwnerId                     string
 	ExternalDNSImage                          string
 	ExternalDNSGoogleProject                  string
+	ExternalDNSInterval                       time.Duration
+	ExternalDNSAWSZonesCacheDuration          time.Duration
 	AdditionalOperatorEnvVars                 map[string]string
 	EnableAdminRBACGeneration                 bool
 	EnableUWMTelemetryRemoteWrite             bool
@@ -191,6 +193,12 @@ func (o *Options) Validate() error {
 		}
 		if len(o.ExternalDNSDomainFilter) == 0 {
 			errs = append(errs, fmt.Errorf("--external-dns-domain-filter is required with --external-dns-provider"))
+		}
+		if o.ExternalDNSInterval < 0 {
+			errs = append(errs, fmt.Errorf("--external-dns-interval must be a positive duration"))
+		}
+		if o.ExternalDNSAWSZonesCacheDuration < 0 {
+			errs = append(errs, fmt.Errorf("--external-dns-aws-zones-cache-duration must be a positive duration"))
 		}
 	}
 	if o.HyperShiftImage != HyperShiftImage && len(o.ImageRefsFile) > 0 {
@@ -313,6 +321,8 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.ExternalDNSTxtOwnerId, "external-dns-txt-owner-id", "", "external-dns TXT registry owner ID.")
 	cmd.PersistentFlags().StringVar(&opts.ExternalDNSImage, "external-dns-image", opts.ExternalDNSImage, "Image to use for external-dns")
 	cmd.PersistentFlags().StringVar(&opts.ExternalDNSGoogleProject, "external-dns-google-project", "", "Google Cloud project ID for DNS zone (optional for GCP provider; falls back to EXTERNAL_DNS_GOOGLE_PROJECT env var or GCP metadata server)")
+	cmd.PersistentFlags().DurationVar(&opts.ExternalDNSInterval, "external-dns-interval", assets.DefaultExternalDNSInterval, "How often external-dns will reconcile DNS records.")
+	cmd.PersistentFlags().DurationVar(&opts.ExternalDNSAWSZonesCacheDuration, "external-dns-aws-zones-cache-duration", assets.DefaultExternalDNSAWSZonesCacheDuration, "How long to cache the list of AWS Route53 hosted zones. Higher values reduce ListHostedZones API calls. Only applies when --external-dns-provider=aws.")
 	cmd.PersistentFlags().BoolVar(&opts.EnableAdminRBACGeneration, "enable-admin-rbac-generation", opts.EnableAdminRBACGeneration, "Generate RBAC manifests for hosted cluster admins")
 	cmd.PersistentFlags().StringVar(&opts.ImageRefsFile, "image-refs", opts.ImageRefsFile, "Image references to user in Hypershift installation")
 	cmd.PersistentFlags().StringVar(&opts.AdditionalTrustBundle, "additional-trust-bundle", opts.AdditionalTrustBundle, "Path to a file with user CA bundle")
@@ -1076,15 +1086,17 @@ func setupExternalDNS(opts Options, operatorNamespace *corev1.Namespace) ([]crcl
 	}
 
 	externalDNSDeployment := assets.ExternalDNSDeployment{
-		Namespace:         operatorNamespace,
-		Image:             opts.ExternalDNSImage,
-		ServiceAccount:    externalDNSServiceAccount,
-		Provider:          assets.ExternalDNSProvider(opts.ExternalDNSProvider),
-		DomainFilter:      opts.ExternalDNSDomainFilter,
-		CredentialsSecret: externalDNSSecret,
-		TxtOwnerId:        opts.ExternalDNSTxtOwnerId,
-		Proxy:             proxy,
-		GoogleProject:     opts.ExternalDNSGoogleProject,
+		Namespace:             operatorNamespace,
+		Image:                 opts.ExternalDNSImage,
+		ServiceAccount:        externalDNSServiceAccount,
+		Provider:              assets.ExternalDNSProvider(opts.ExternalDNSProvider),
+		DomainFilter:          opts.ExternalDNSDomainFilter,
+		CredentialsSecret:     externalDNSSecret,
+		TxtOwnerId:            opts.ExternalDNSTxtOwnerId,
+		Proxy:                 proxy,
+		GoogleProject:         opts.ExternalDNSGoogleProject,
+		Interval:              opts.ExternalDNSInterval,
+		AWSZonesCacheDuration: opts.ExternalDNSAWSZonesCacheDuration,
 	}.Build()
 	objects = append(objects, externalDNSDeployment)
 


### PR DESCRIPTION
## What this PR does / why we need it:

Adds two new configurable CLI flags to `hypershift install` that allow operators to tune
external-dns behavior and reduce AWS Route53 API usage:

- `--external-dns-interval`: Controls how often external-dns reconciles DNS records for
  drift detection. Default is `1m`. Since `--events` is already used, this interval only
  affects drift reconciliation and can safely be increased (e.g. `5m` or `10m`).
- `--external-dns-aws-zones-cache-duration`: Controls how long the list of AWS Route53
  hosted zones is cached. Default is `1h`. Higher values reduce `ListHostedZones` API calls.

AWS Route53 limits API requests to 5/sec per account, and external-dns can generate ~17K
calls/hour (mostly `ListHostedZones` and `ListResourceRecordSets`). These flags help
operators reduce impact on AWS API rate limits.

### Usage example:
```bash
hypershift install \
  --external-dns-provider aws \
  --external-dns-credentials /path/to/creds \
  --external-dns-domain-filter example.com \
  --external-dns-interval 5m \
  --external-dns-aws-zones-cache-duration 2h
```

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/CNTRLPLANE-634

## Special notes for your reviewer:

The defaults remain unchanged (1m interval, 1h zones cache) so this is backward compatible.
The `ExternalDNSDeployment` struct gains two new optional fields that default to the current
hardcoded values when zero-valued.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve CNTRLPLANE-634`